### PR TITLE
fix: release-plz order

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,7 +1,7 @@
 [workspace]
 allow_dirty         = false
-semver_check        = true
 dependencies_update = true
+semver_check        = true
 
 # Configure the order of releases
 [[package]]
@@ -12,5 +12,5 @@ publish = true
 name    = "learnerd"
 publish = true
 # This will make release-plz wait for learner to be published
-publish_delay       = "30s"
 dependencies_update = [{ name = "learner", version_template = "={{version}}" }]
+publish_delay       = "30s"

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,16 @@
+[workspace]
+allow_dirty         = false
+semver_check        = true
+dependencies_update = true
+
+# Configure the order of releases
+[[package]]
+name    = "learner"
+publish = true
+
+[[package]]
+name    = "learnerd"
+publish = true
+# This will make release-plz wait for learner to be published
+publish_delay       = "30s"
+dependencies_update = [{ name = "learner", version_template = "={{version}}" }]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,6 @@ readme     = "README.md"
 repository = "https://github.com/autoparallel/learner"
 
 [workspace.dependencies]
-# local
-learner = { path = "crates/learner" }
-
 # shared
 thiserror = "1.0"
 tokio     = { version = "1.41", features = ["full"] }

--- a/crates/learnerd/Cargo.toml
+++ b/crates/learnerd/Cargo.toml
@@ -10,8 +10,7 @@ repository.workspace = true
 version              = "0.1.1"
 
 [dependencies]
-learner.workspace = true # for development
-# learner = "0.2.1" # for release
+learner = { version = "0.2", path = "../learner" }
 
 clap.workspace               = true
 console.workspace            = true


### PR DESCRIPTION
Attempts to have the order of packages for release set with a `.release-plz.toml`, update the dep for `learner` used in `learnerd` in that, also changes the way we bring in `learner` to that crate as well.