### PR TITLE
Add case for missing retrievers

### DIFF
--- a/crates/learner/src/retriever/mod.rs
+++ b/crates/learner/src/retriever/mod.rs
@@ -98,6 +98,30 @@ pub struct Retriever {
   configs: HashMap<String, RetrieverConfig>,
 }
 
+impl Retriever {
+  /// Checks whether the retreivers map is empty.
+  ///
+  /// This is useful for handling the case where no retreivers are specified and
+  /// we wish to inform the user.
+  ///
+  /// # Examples
+  ///
+  /// ```no_run
+  /// # use learner::retriever::Retriever;
+  /// # use learner::error::LearnerError;
+  ///
+  /// # fn check_is_empty() -> Result<(), LearnerError> {
+  /// let retriever = Retriever::new();
+  ///
+  /// if retriever.is_empty() {
+  ///   return Err(LearnerError::Config("No retriever configured.".to_string()));
+  /// }
+  /// # Ok(())
+  /// # }
+  /// ```
+  pub fn is_empty(&self) -> bool { self.configs.is_empty() }
+}
+
 /// Configuration for a specific paper source retriever.
 ///
 /// This struct defines how to interact with a particular paper source's API,

--- a/crates/learnerd/src/commands/add.rs
+++ b/crates/learnerd/src/commands/add.rs
@@ -24,6 +24,12 @@ pub struct AddArgs {
 pub async fn add<I: UserInteraction>(interaction: &mut I, add_args: AddArgs) -> Result<Paper> {
   let AddArgs { identifier, pdf, no_pdf } = add_args;
 
+  if interaction.learner().retriever.is_empty() {
+    return Err(LearnerdError::Learner(LearnerError::Config(
+      "No retriever configured.".to_string(),
+    )));
+  }
+
   let (source, sanitized_identifier) =
     interaction.learner().retriever.sanitize_identifier(&identifier)?;
   let papers = Query::by_source(&source, &sanitized_identifier)


### PR DESCRIPTION
## 📝 Description

Adds a more intuitive error message for missing retrievers. Additionally, it adds a function in `Retriever` to check whether the configs hash map is populated.

## 🔍 Changes include

- [x] 🐛 Bugfix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ⚡ Performance improvement
- [ ] 🔨 Refactoring
- [ ] ✅ Test updates

## 🧪 Testing

Trust me bro

## 📋 Checklist

- [x] I have tested the changes locally
- [x] I have updated the documentation accordingly
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass locally

## 🔗 Linked Issues

closes #139 